### PR TITLE
Use 5 enroll stages to match settings in imgdev

### DIFF
--- a/libfprint/drivers/vfs101.c
+++ b/libfprint/drivers/vfs101.c
@@ -65,7 +65,7 @@
 #define VFS_IMG_BEST_CONRAST	128
 
 /* Number of enroll stages */
-#define VFS_NR_ENROLL		1
+#define VFS_NR_ENROLL		5
 
 /* Device parameters address */
 #define VFS_PAR_000E			0x000e


### PR DESCRIPTION
This fixes a hang in the fprint_demo enrollment process, where
action_completed() returned TRUE after VFS_NR_ENROLL=1 scan, but the
program expected fp_dev_get_nr_enroll_stages()=5 scans.

Signed-off-by: Ray Lehtiniemi rayl@mail.com
